### PR TITLE
Clean template remnants and clarify NSI badges

### DIFF
--- a/glossary.html
+++ b/glossary.html
@@ -68,6 +68,36 @@
           </section>
 
           <section>
+            <h2 id="glossary-states">Sustainability states</h2>
+            <p>
+              Every briefing carries a sustainability state badge derived from the packet <code>phase</code> field. These labels
+              translate analyst judgement about structural stress into a quick read on urgency and help readers interpret NSI
+              moves at a glance.
+            </p>
+            <div class="callout">
+              <span class="callout__label">Phase quick reference</span>
+              <ul>
+                <li id="sustainability-state-watch">
+                  <strong>Watch</strong> — Baseline condition with mixed signals. NSI typically hovers between 45 and 60 while
+                  metrics warrant closer monitoring for deterioration or recovery.
+                </li>
+                <li id="sustainability-state-elevated">
+                  <strong>Elevated</strong> — Sustained downward pressure or tightening fundamentals. NSI often drifts below 50
+                  alongside hard metrics tilting toward Tier Y thresholds.
+                </li>
+                <li id="sustainability-state-critical">
+                  <strong>Critical</strong> — Acute stress that demands mitigation. NSI drops toward the low 40s or below and hard
+                  metrics show Tier X readings or binding capacity constraints.
+                </li>
+              </ul>
+              <p>
+                Badges link back to this reference so the meaning of each label remains consistent across posts, the archive, and
+                any regenerated pages.
+              </p>
+            </div>
+          </section>
+
+          <section>
             <h2 id="glossary-score">Cluster metadata</h2>
             <p>
               Each cluster entry in <code>data/leaderboard.json</code> contains fields sourced from the packet and enriched during

--- a/index.html
+++ b/index.html
@@ -53,6 +53,11 @@
               and policy show where stress is building. Follow the daily sustainability index,
               drill into cluster briefings, and monitor hard metrics that ground the narrative.
             </p>
+            <p class="hero-definition">
+              <strong>NSI</strong> stands for <em>Net Sustainability Index</em>: a 0–100 score where 50 is
+              neutral, readings above 60 flag resilient momentum, and values slipping toward 45 warn
+              that stresses are compounding.
+            </p>
             <div class="hero-actions">
               <a class="btn btn-primary" href="#health">Explore the dashboard</a>
               <a class="btn btn-secondary" href="#latest">Read the latest briefings</a>

--- a/posts/enterprise-ai-adoption-booming.html
+++ b/posts/enterprise-ai-adoption-booming.html
@@ -49,7 +49,7 @@
             <p class="post-date">28 September 2025</p>
             <h1>Enterprise AI Adoption Grows But Monetization Lags</h1>
             <div class="post-meta">
-              <a href="../glossary.html#trigger-risk-watch" class="risk-badge risk-badge--watch glossary-link" data-confirm-link="true" data-preview-label="Trigger risk badge · Watch">Trigger risk: Watch</a>
+              <a href="../glossary.html#sustainability-state-watch" class="risk-badge risk-badge--watch glossary-link" data-confirm-link="true" data-preview-label="Sustainability state badge · Watch">Sustainability state: Watch</a>
               <a href="../glossary.html#adoption-update" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Event type · Adoption Update">Adoption Update</a>
               <a href="../glossary.html#enterprise-demand" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Cluster · ENTERPRISE DEMAND">ENTERPRISE DEMAND</a>
               <a href="../glossary.html#glossary-confidence" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Confidence scale">Confidence: Medium</a>

--- a/posts/hyperscalers-ai-capex-boom.html
+++ b/posts/hyperscalers-ai-capex-boom.html
@@ -49,7 +49,7 @@
             <p class="post-date">28 September 2025</p>
             <h1>Hyperscalers Expand AI Capex Amid $7 Trillion Buildout</h1>
             <div class="post-meta">
-              <a href="../glossary.html#trigger-risk-elevated" class="risk-badge risk-badge--medium glossary-link" data-confirm-link="true" data-preview-label="Trigger risk badge · Elevated">Trigger risk: Elevated</a>
+              <a href="../glossary.html#sustainability-state-elevated" class="risk-badge risk-badge--medium glossary-link" data-confirm-link="true" data-preview-label="Sustainability state badge · Elevated">Sustainability state: Elevated</a>
               <a href="../glossary.html#investment-update" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Event type · Investment Update">Investment Update</a>
               <a href="../glossary.html#ai-capex" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Cluster · AI CAPEX">AI CAPEX</a>
               <a href="../glossary.html#glossary-confidence" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Confidence scale">Confidence: Medium</a>

--- a/posts/power-grid-bottleneck-ai.html
+++ b/posts/power-grid-bottleneck-ai.html
@@ -49,7 +49,7 @@
             <p class="post-date">28 September 2025</p>
             <h1>Power Constraints Threaten AI Data-Center Growth</h1>
             <div class="post-meta">
-              <a href="../glossary.html#trigger-risk-critical" class="risk-badge risk-badge--high glossary-link" data-confirm-link="true" data-preview-label="Trigger risk badge · Critical">Trigger risk: Critical</a>
+              <a href="../glossary.html#sustainability-state-critical" class="risk-badge risk-badge--high glossary-link" data-confirm-link="true" data-preview-label="Sustainability state badge · Critical">Sustainability state: Critical</a>
               <a href="../glossary.html#power-update" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Event type · Power Update">Power Update</a>
               <a href="../glossary.html#power-grid" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Cluster · POWER GRID">POWER GRID</a>
               <a href="../glossary.html#glossary-confidence" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Confidence scale">Confidence: Medium</a>

--- a/posts/regulation-and-geopolitics-shape-ai.html
+++ b/posts/regulation-and-geopolitics-shape-ai.html
@@ -49,7 +49,7 @@
             <p class="post-date">28 September 2025</p>
             <h1>Regulation and Geopolitics Reshape AI Landscape</h1>
             <div class="post-meta">
-              <a href="../glossary.html#trigger-risk-watch" class="risk-badge risk-badge--watch glossary-link" data-confirm-link="true" data-preview-label="Trigger risk badge · Watch">Trigger risk: Watch</a>
+              <a href="../glossary.html#sustainability-state-watch" class="risk-badge risk-badge--watch glossary-link" data-confirm-link="true" data-preview-label="Sustainability state badge · Watch">Sustainability state: Watch</a>
               <a href="../glossary.html#policy-update" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Event type · Policy Update">Policy Update</a>
               <a href="../glossary.html#policy-geopolitics" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Cluster · POLICY GEOPOLITICS">POLICY GEOPOLITICS</a>
               <a href="../glossary.html#glossary-confidence" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Confidence scale">Confidence: Medium</a>

--- a/posts/semiconductor-supply-strains-and-policy-risks.html
+++ b/posts/semiconductor-supply-strains-and-policy-risks.html
@@ -49,7 +49,7 @@
             <p class="post-date">28 September 2025</p>
             <h1>AI Chip Demand Strains Semiconductor Supply Amid Policy Risks</h1>
             <div class="post-meta">
-              <a href="../glossary.html#trigger-risk-elevated" class="risk-badge risk-badge--medium glossary-link" data-confirm-link="true" data-preview-label="Trigger risk badge · Elevated">Trigger risk: Elevated</a>
+              <a href="../glossary.html#sustainability-state-elevated" class="risk-badge risk-badge--medium glossary-link" data-confirm-link="true" data-preview-label="Sustainability state badge · Elevated">Sustainability state: Elevated</a>
               <a href="../glossary.html#supply-update" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Event type · Supply Update">Supply Update</a>
               <a href="../glossary.html#semi-supply" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Cluster · SEMI SUPPLY">SEMI SUPPLY</a>
               <a href="../glossary.html#glossary-confidence" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Confidence scale">Confidence: Medium</a>

--- a/posts/unit-economics-improving-but-margins-thin.html
+++ b/posts/unit-economics-improving-but-margins-thin.html
@@ -49,7 +49,7 @@
             <p class="post-date">28 September 2025</p>
             <h1>AI Unit Costs Plunge While Margins Remain Thin</h1>
             <div class="post-meta">
-              <a href="../glossary.html#trigger-risk-watch" class="risk-badge risk-badge--watch glossary-link" data-confirm-link="true" data-preview-label="Trigger risk badge · Watch">Trigger risk: Watch</a>
+              <a href="../glossary.html#sustainability-state-watch" class="risk-badge risk-badge--watch glossary-link" data-confirm-link="true" data-preview-label="Sustainability state badge · Watch">Sustainability state: Watch</a>
               <a href="../glossary.html#cost-update" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Event type · Cost Update">Cost Update</a>
               <a href="../glossary.html#unit-economics" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Cluster · UNIT ECONOMICS">UNIT ECONOMICS</a>
               <a href="../glossary.html#glossary-confidence" class="glossary-link" data-confirm-link="true" data-preview-label="Glossary → Confidence scale">Confidence: High</a>

--- a/scripts/ingest_llm_packet.py
+++ b/scripts/ingest_llm_packet.py
@@ -200,21 +200,21 @@ def render_phase_badge(phase: Optional[str]) -> Optional[str]:
     mapping = {
         "critical": (
             "risk-badge--high",
-            "Trigger risk: Critical",
-            "trigger-risk-critical",
-            "Trigger risk badge · Critical",
+            "Sustainability state: Critical",
+            "sustainability-state-critical",
+            "Sustainability state badge · Critical",
         ),
         "elevated": (
             "risk-badge--medium",
-            "Trigger risk: Elevated",
-            "trigger-risk-elevated",
-            "Trigger risk badge · Elevated",
+            "Sustainability state: Elevated",
+            "sustainability-state-elevated",
+            "Sustainability state badge · Elevated",
         ),
         "watch": (
             "risk-badge--watch",
-            "Trigger risk: Watch",
-            "trigger-risk-watch",
-            "Trigger risk badge · Watch",
+            "Sustainability state: Watch",
+            "sustainability-state-watch",
+            "Sustainability state badge · Watch",
         ),
     }
     if normalized in mapping:
@@ -222,9 +222,9 @@ def render_phase_badge(phase: Optional[str]) -> Optional[str]:
     else:
         class_name, text, slug, preview = (
             "risk-badge--watch",
-            f"Phase: {label.title()}",
+            f"Sustainability state: {label.title()}",
             None,
-            f"Trigger risk badge · {label.title()}",
+            f"Sustainability state badge · {label.title()}",
         )
     return render_glossary_link(
         text,
@@ -292,7 +292,7 @@ def render_post_page(
 ) -> str:
     """Wrap briefing content in the site layout template."""
 
-    safe_title = title.strip() or "Trigger Risk Monitor briefing"
+    safe_title = title.strip() or "AI Sustainability Monitor briefing"
     meta_description = (description or extract_text_summary(content, fallback=safe_title)).strip()
     subtitle_text = str(subtitle or "").strip()
 

--- a/tags/index.html
+++ b/tags/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Tagged Briefings — Trigger Risk Monitor</title>
+    <title>Tagged Briefings — AI Sustainability Monitor</title>
     <meta
       name="description"
-      content="Browse Trigger Risk Monitor briefings grouped by thematic tags and clusters."
+      content="Browse AI Sustainability Monitor briefings grouped by thematic tags and clusters."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -21,7 +21,7 @@
   <body>
     <header class="site-header" id="top">
       <div class="container header-inner">
-        <a class="logo" href="../index.html">Trigger Risk Monitor</a>
+        <a class="logo" href="../index.html">AI Sustainability Monitor</a>
         <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">
           <span class="sr-only">Toggle navigation</span>
           <span class="nav-toggle__bar"></span>
@@ -30,12 +30,12 @@
         </button>
         <nav id="site-nav" class="site-nav" aria-label="Primary">
           <ul>
-            <li><a href="../index.html#leaderboard">Leaderboard</a></li>
+            <li><a href="../index.html#health">AI health</a></li>
             <li><a href="../index.html#latest">Latest briefings</a></li>
             <li><a href="../posts/index.html">All briefings</a></li>
             <li><a href="../methodology.html">Methodology</a></li>
             <li><a href="../glossary.html">Glossary</a></li>
-            <li><a href="../index.html#dashboard">Trigger dashboard</a></li>
+            <li><a href="../index.html#metrics">Hard metrics</a></li>
             <li><a href="../index.html#playbook">Playbook</a></li>
           </ul>
         </nav>
@@ -86,10 +86,9 @@
     <footer class="site-footer">
       <div class="container footer-inner">
         <div>
-          <a class="logo" href="#top">Trigger Risk Monitor</a>
+          <a class="logo" href="#top">AI Sustainability Monitor</a>
           <p class="footer-note">
-            Independent research on the 18.6-year land cycle. Built for investors who want to
-            see turning points before the crowd.
+            Tracking infrastructure, demand, and policy signals shaping the AI boom.
           </p>
         </div>
         <div class="footer-links">
@@ -97,7 +96,7 @@
           <a href="../posts/index.html">All briefings</a>
           <a href="../methodology.html">Methodology</a>
           <a href="../glossary.html">Glossary</a>
-          <a href="../index.html#dashboard">Trigger dashboard</a>
+          <a href="../index.html#metrics">Hard metrics</a>
           <a href="../index.html#playbook">Playbook</a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- rebrand the tag archive and post badges to remove remaining Trigger template references
- add sustainability-state anchors in the glossary and explain how NSI phases map to badges
- highlight the Net Sustainability Index definition on the homepage hero so readers understand the score

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68d9a73cb910832a99e57b476c28f839