### PR TITLE
Remove contact and playbook links from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,6 @@
             <li><a href="methodology.html">Methodology</a></li>
             <li><a href="glossary.html">Glossary</a></li>
             <li><a href="#metrics">Hard metrics</a></li>
-            <li><a href="#playbook">Playbook</a></li>
           </ul>
         </nav>
       </div>
@@ -197,8 +196,6 @@
           <a href="posts/index.html">Briefing archive</a>
           <a href="methodology.html">Methodology</a>
           <a href="glossary.html">Glossary</a>
-          <a href="mailto:signals@aisustainability.monitor">Contact</a>
-          <a href="#playbook">Playbook</a>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- remove the Contact and Playbook links from the landing page navigation and footer

## Testing
- python - <<'PY' (link scan)


------
https://chatgpt.com/codex/tasks/task_e_68d9b3dcbd14832a8f6c422298ebf15e